### PR TITLE
Missing comma for a command

### DIFF
--- a/Missing.sublime-commands
+++ b/Missing.sublime-commands
@@ -119,7 +119,7 @@
     { "caption": "View: Toggle Gutter", "command": "toggle_setting", "args": {"setting": "gutter"} },
     { "caption": "View: Toggle Line Numbers", "command": "toggle_setting", "args": {"setting": "line_numbers"} },
     { "caption": "Check for Updates", "command": "update_check" },
-    { "caption": "Reveal Current File in Side Bar", "command": "reveal_in_side_bar" }
+    { "caption": "Reveal Current File in Side Bar", "command": "reveal_in_side_bar" },
 
     // Selections
     { "caption": "Invert Selection", "command": "invert_selection"}


### PR DESCRIPTION
Missing comma at the end of file, file was not loaded and commands didn't show up.